### PR TITLE
Handle numeric string reaction counts

### DIFF
--- a/placeholder-main/components/ReactionBar.tsx
+++ b/placeholder-main/components/ReactionBar.tsx
@@ -32,7 +32,10 @@ export default function ReactionBar({
   const merged = useMemo<ReactionCounts>(() => {
     const safe: ReactionCounts = { ...DEFAULTS };
     for (const [k, v] of Object.entries(counts || {})) {
-      safe[k] = Number.isFinite(v) ? Number(v) : 0;
+      // Accept numeric values or numeric strings from APIs; anything
+      // non-numeric falls back to 0 so the UI stays stable.
+      const num = Number(v);
+      safe[k] = Number.isFinite(num) ? num : 0;
     }
     return safe;
   }, [counts]);


### PR DESCRIPTION
## Summary
- ensure ReactionBar merges numeric string counts safely

## Testing
- `npx tsc --noEmit`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6899b15992fc8321b8ec66034b2c3b04