### PR TITLE
Guard optional browser APIs and sanitize reaction counts

### DIFF
--- a/placeholder-main/app/page.tsx
+++ b/placeholder-main/app/page.tsx
@@ -62,6 +62,7 @@ export default function Page() {
 
   // measure header height → CSS var so sticky math is exact
   useEffect(() => {
+    if (typeof ResizeObserver === 'undefined') return;
     const header = document.querySelector<HTMLElement>('header.topbar');
     if (!header) return;
     const set = () =>

--- a/placeholder-main/components/ReactionBar.tsx
+++ b/placeholder-main/components/ReactionBar.tsx
@@ -35,7 +35,8 @@ export default function ReactionBar({
       // Accept numeric values or numeric strings from APIs; anything
       // non-numeric falls back to 0 so the UI stays stable.
       const num = Number(v);
-      safe[k] = Number.isFinite(num) ? num : 0;
+      // clamp at 0 so bogus negative values don't show
+      safe[k] = Number.isFinite(num) ? Math.max(0, num) : 0;
     }
     return safe;
   }, [counts]);

--- a/placeholder-main/components/SetHeaderVar.tsx
+++ b/placeholder-main/components/SetHeaderVar.tsx
@@ -5,6 +5,7 @@ import { useEffect, useLayoutEffect } from 'react';
 export default function SetHeaderVar({ headerSelector = '[data-app-header]' }) {
   const useIso = typeof window === 'undefined' ? useEffect : useLayoutEffect;
   useIso(() => {
+    if (typeof ResizeObserver === 'undefined') return;
     const header = document.querySelector<HTMLElement>(headerSelector);
     if (!header) return;
     const set = () =>


### PR DESCRIPTION
## Summary
- clamp negative reaction counts to zero
- avoid runtime crashes when `ResizeObserver` is missing
- guard header sizing logic on browsers without `ResizeObserver`

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689a50a0b1888321b1b58bd2ccbd9050