### PR TITLE
refactor: remove unused useMemo

### DIFF
--- a/placeholder-main/components/InfiniteFeed.tsx
+++ b/placeholder-main/components/InfiniteFeed.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 
 type Post = { id: string; author: string; time: string; text: string; image?: string };
 


### PR DESCRIPTION
## Summary
- remove unused `useMemo` from `InfiniteFeed` React import

## Testing
- `npm test` *(fails: Missing script "test")*
- `npx tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_689a51526fa8832184caced2335398b8