### PR TITLE
Add sandbox to UEStream iframe

### DIFF
--- a/placeholder-main/components/UEStream.tsx
+++ b/placeholder-main/components/UEStream.tsx
@@ -11,6 +11,7 @@ export default function UEStream() {
           title="Unreal Stream"
           style={{ width: "100%", height: "100%", border: 0 }}
           allow="autoplay; fullscreen; microphone; camera; clipboard-read; clipboard-write"
+          sandbox="allow-same-origin allow-scripts allow-forms allow-pointer-lock"
         />
       ) : (
         <>Set <code>NEXT_PUBLIC_UE_STREAM_URL</code> to enable Unreal streaming.</>


### PR DESCRIPTION
## Summary
- add sandbox attribute to UEStream iframe with required permissions

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689a5154dfb08321a4884eb802f82587