### PR TITLE
Reset RemixPicker selections on close

### DIFF
--- a/placeholder-main/components/RemixPicker.tsx
+++ b/placeholder-main/components/RemixPicker.tsx
@@ -1,7 +1,7 @@
 // components/RemixPicker.tsx
 "use client";
 
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 
 type Props = {
   open: boolean;
@@ -19,6 +19,11 @@ const ALL_APIS = [
 
 export default function RemixPicker({ open, onClose, onConfirm }: Props) {
   const [selected, setSelected] = useState<string[]>([]);
+  useEffect(() => {
+    if (!open) {
+      setSelected([]);
+    }
+  }, [open]);
   if (!open) return null;
 
   function toggle(name: string) {


### PR DESCRIPTION
## Summary
- clear RemixPicker selections when the dialog is closed

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build`
- `node -r jsdom-global/register remixPicker.test.js`


------
https://chatgpt.com/codex/tasks/task_e_689a5153e8e0832196eb7947e0cdb949