### PR TITLE
feat: allow deselecting reaction

### DIFF
--- a/placeholder-main/components/PostCard.tsx
+++ b/placeholder-main/components/PostCard.tsx
@@ -20,7 +20,7 @@ export default function PostCard({
   onReact,
 }: {
   post: Post;
-  onReact?: (prev: string | null, next: string) => void;
+  onReact?: (prev: string | null, next: string | null) => void;
 }) {
   const p = post as unknown as AnyObj; // tolerate partial data without exploding
   const handleReact = onReact ?? (() => {});

--- a/placeholder-main/components/ReactionBar.tsx
+++ b/placeholder-main/components/ReactionBar.tsx
@@ -11,7 +11,7 @@ export type Props = {
   /** Map of emoji -> count. Missing keys default to 0. */
   counts?: ReactionCounts;
   /** Notifies parent of a change: previous selection (or null) and new selection */
-  onChange?: (prev: string | null, next: string) => void;
+  onChange?: (prev: string | null, next: string | null) => void;
   /** Optional className so parent can style/position */
   className?: string;
 };
@@ -42,9 +42,10 @@ export default function ReactionBar({
 
   const handleClick = (next: string) => {
     setSelected(prev => {
-      try { onChange?.(prev, next); } catch { /* swallow */ }
-      // toggle: clicking the same reaction keeps it selected (no unlike yet)
-      return next;
+      const isSame = prev === next;
+      try { onChange?.(prev, isSame ? null : next); } catch { /* swallow */ }
+      // clear selection when clicking the active reaction
+      return isSame ? null : next;
     });
   };
 


### PR DESCRIPTION
## Summary
- allow clearing a previously selected reaction
- update PostCard to accept deselection events

## Testing
- `npm test` *(fails: Missing script "test")*
- `npx tsc --noEmit`

------
https://chatgpt.com/codex/tasks/task_e_689a51559b888321b400af4a98bf3ba7