### PR TITLE
fix: specify button type in Topbar

### DIFF
--- a/placeholder-main/components/Topbar.tsx
+++ b/placeholder-main/components/Topbar.tsx
@@ -6,7 +6,7 @@ import styles from "./topbar.module.css";
 export default function Topbar({ onAvatarClick }: { onAvatarClick: () => void }) {
   return (
     <div className={styles.topbar}>
-      <button className={styles.avatar} onClick={onAvatarClick} aria-label="Open menu">SN</button>
+      <button type="button" className={styles.avatar} onClick={onAvatarClick} aria-label="Open menu">SN</button>
       <div className={styles.spacer} />
       <a className={styles.link} href="https://github.com/BP-H" target="_blank" rel="noopener noreferrer">GitHub</a>
     </div>


### PR DESCRIPTION
## Summary
- prevent implicit form submission by setting avatar button type

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689a517a9ff883219b3167e7971eda72