### PR TITLE
refactor: remove unused useMemo import

### DIFF
--- a/placeholder-main/components/InfiniteFeed.tsx
+++ b/placeholder-main/components/InfiniteFeed.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 
 type Post = { id: string; author: string; time: string; text: string; image?: string };
 


### PR DESCRIPTION
## Summary
- remove unused useMemo import from InfiniteFeed component

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689a517ceba083219a361546c45b5f3b