### PR TITLE
Handle Escape key in RemixPicker

### DIFF
--- a/placeholder-main/components/RemixPicker.tsx
+++ b/placeholder-main/components/RemixPicker.tsx
@@ -1,7 +1,7 @@
 // components/RemixPicker.tsx
 "use client";
 
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 
 type Props = {
   open: boolean;
@@ -19,6 +19,14 @@ const ALL_APIS = [
 
 export default function RemixPicker({ open, onClose, onConfirm }: Props) {
   const [selected, setSelected] = useState<string[]>([]);
+  useEffect(() => {
+    if (!open) return;
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    };
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [open, onClose]);
   if (!open) return null;
 
   function toggle(name: string) {


### PR DESCRIPTION
## Summary
- Close RemixPicker when Escape is pressed by registering a keydown handler while the dialog is open

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689a51811fd4832198111fafce8b0ebf