### PR TITLE
Clean up feed timeout in placeholder feed loading

### DIFF
--- a/placeholder-main/app/page.tsx
+++ b/placeholder-main/app/page.tsx
@@ -40,13 +40,14 @@ export default function Page() {
   const sentinelRef = useRef<HTMLDivElement | null>(null);
 
   useEffect(() => {
+    let timer: ReturnType<typeof setTimeout> | null = null;
     if (!sentinelRef.current) return;
     const io = new IntersectionObserver(
       (entries) => {
         const [e] = entries;
         if (!e.isIntersecting || loading || !hasMore) return;
         setLoading(true);
-        setTimeout(() => {
+        timer = setTimeout(() => {
           const next = makeBatch(page * 12, 12);
           setItems((prev) => [...prev, ...next]);
           setPage((p) => p + 1);
@@ -57,7 +58,10 @@ export default function Page() {
       { rootMargin: '1200px 0px 800px 0px' }
     );
     io.observe(sentinelRef.current);
-    return () => io.disconnect();
+    return () => {
+      if (timer) clearTimeout(timer);
+      io.disconnect();
+    };
   }, [page, loading, hasMore]);
 
   // measure header height → CSS var so sticky math is exact


### PR DESCRIPTION
## Summary
- track feed loading setTimeout id in variable
- clear timeout in cleanup before disconnecting observer

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689a51887cb08321af5f6ed23fcafc9e