### PR TITLE
Check post alt text before generating fallback

### DIFF
--- a/placeholder-main/components/PostCard.tsx
+++ b/placeholder-main/components/PostCard.tsx
@@ -26,9 +26,14 @@ export default function PostCard({
   const handleReact = onReact ?? (() => {});
 
   // Safe, descriptive alt text
-  const imgAlt =
-    (typeof p.text === 'string' && p.text.trim().slice(0, 80)) ||
-    (p.author?.name ? `${p.author.name}'s post image` : 'post image');
+  const imgAlt: string =
+    typeof p.alt === 'string' && p.alt.trim()
+      ? p.alt.trim()
+      : typeof p.text === 'string' && p.text.trim()
+      ? p.text.trim().slice(0, 80)
+      : p.author?.name
+      ? `${p.author.name}'s post image`
+      : 'post image';
 
   // Deterministic seed for 3D (varies per post but stable)
   const threeSeed = String(p.id ?? Math.random());


### PR DESCRIPTION
## Summary
- check `p.alt` first when computing PostCard `imgAlt`
- fall back to existing text/author logic and keep the result a string

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_689a518a552c83218756c8867c1db4be