### PR TITLE
Use AbortController to cancel agent fetch

### DIFF
--- a/placeholder-main/components/AgentsRail.tsx
+++ b/placeholder-main/components/AgentsRail.tsx
@@ -17,13 +17,13 @@ export default function AgentsRail() {
   const [agents, setAgents] = useState<Agent[]>([]);
 
   useEffect(() => {
-    let mounted = true;
+    const controller = new AbortController();
     (async () => {
       try {
-        const data = await api.listAgents();
-        if (mounted) setAgents(data);
+        const data = await api.listAgents(controller.signal);
+        if (!controller.signal.aborted) setAgents(data);
       } catch {
-        if (mounted)
+        if (!controller.signal.aborted)
           setAgents([
             { id: "a1", handle: "nova_ai", display_name: "Nova AI", resonance: 98 },
             { id: "a2", handle: "karina", display_name: "Karina", resonance: 91 },
@@ -32,7 +32,9 @@ export default function AgentsRail() {
           ]);
       }
     })();
-    return () => { mounted = false; };
+    return () => {
+      controller.abort();
+    };
   }, []);
 
   if (!agents.length) return null;

--- a/placeholder-main/libs/api.ts
+++ b/placeholder-main/libs/api.ts
@@ -14,12 +14,12 @@ async function json<T>(input: RequestInfo, init?: RequestInit): Promise<T> {
 
 export const api = {
   // Tries a few common agent endpoints; falls back gracefully
-  async listAgents(): Promise<Agent[]> {
+  async listAgents(signal?: AbortSignal): Promise<Agent[]> {
     if (!BASE) throw new Error("No API base set");
     const paths = ["/agents", "/ai/personas", "/api/agents", "/api/personas"];
     for (const p of paths) {
       try {
-        const r = await json<any>(`${BASE}${p}`);
+        const r = await json<any>(`${BASE}${p}`, { signal });
         // normalize a little:
         if (Array.isArray(r)) return r as Agent[];
         if (Array.isArray(r?.results)) return r.results as Agent[];


### PR DESCRIPTION
## Summary
- cancel agent fetch in AgentsRail on unmount via `AbortController`
- allow `api.listAgents` to accept an optional abort signal

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689a518ac5848321857e7298959586ee