### PR TITLE
Handle OpenAI provider network errors

### DIFF
--- a/placeholder-main/components/ai/providers.ts
+++ b/placeholder-main/components/ai/providers.ts
@@ -10,13 +10,22 @@ export const registry: Record<string, Provider> = {
   openai: {
     name: 'OpenAI',
     async generate({ prompt, model = 'gpt-4o-mini' }, { apiKey }) {
-      const r = await fetch('https://api.openai.com/v1/chat/completions', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${apiKey}` },
-        body: JSON.stringify({ model, messages: [{ role: 'user', content: prompt }] }),
-      });
-      const j = await r.json();
-      return j?.choices?.[0]?.message?.content ?? '';
+      try {
+        const r = await fetch('https://api.openai.com/v1/chat/completions', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${apiKey}` },
+          body: JSON.stringify({ model, messages: [{ role: 'user', content: prompt }] }),
+        });
+        if (!r.ok) {
+          throw new Error(`OpenAI API error: ${r.status} ${r.statusText}`);
+        }
+        const j = await r.json();
+        return j?.choices?.[0]?.message?.content ?? '';
+      } catch (err) {
+        throw new Error(
+          `Failed to fetch OpenAI completion: ${err instanceof Error ? err.message : String(err)}`
+        );
+      }
     }
   },
   // add: higgsfield, local LLMs, etc. behind the same interface


### PR DESCRIPTION
## Summary
- throw descriptive error when OpenAI API response is not ok
- surface fetch failures with a clear message

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689a518b709c8321ae106edeaf3a64b9