### PR TITLE
feat: close remix menu on escape or outside click

### DIFF
--- a/placeholder-main/components/RemixMenu.tsx
+++ b/placeholder-main/components/RemixMenu.tsx
@@ -1,7 +1,7 @@
 // components/RemixMenu.tsx
 "use client";
 
-import React, { useState } from "react";
+import React, { useState, useEffect, useRef } from "react";
 
 export type RemixMenuProps = {
   /** Called when the user confirms “Create remix”. */
@@ -33,6 +33,7 @@ export function RemixMenu({
   label = "Remix",
 }: RemixMenuProps) {
   const [open, setOpen] = useState(false);
+  const wrapperRef = useRef<HTMLDivElement>(null);
 
   function toggle() {
     setOpen(v => !v);
@@ -49,8 +50,35 @@ export function RemixMenu({
     close();
   }
 
+  useEffect(() => {
+    if (!open) return;
+
+    function handleKeydown(e: KeyboardEvent) {
+      if (e.key === "Escape") close();
+    }
+
+    function handleMousedown(e: MouseEvent) {
+      const wrapper = wrapperRef.current;
+      if (wrapper && !wrapper.contains(e.target as Node)) {
+        close();
+      }
+    }
+
+    document.addEventListener("keydown", handleKeydown);
+    document.addEventListener("mousedown", handleMousedown);
+
+    return () => {
+      document.removeEventListener("keydown", handleKeydown);
+      document.removeEventListener("mousedown", handleMousedown);
+    };
+  }, [open]);
+
   return (
-    <div className={className} style={{ position: "relative", display: "inline-block" }}>
+    <div
+      ref={wrapperRef}
+      className={className}
+      style={{ position: "relative", display: "inline-block" }}
+    >
       <button
         type="button"
         className="sn-btn"


### PR DESCRIPTION
## Summary
- close RemixMenu when pressing Escape or clicking outside
- add event listeners with proper cleanup

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689a518ce4d08321852ec37e06e429fc