### PR TITLE
Reset RemixPicker selections on open and handle Escape

### DIFF
--- a/placeholder-main/components/RemixPicker.tsx
+++ b/placeholder-main/components/RemixPicker.tsx
@@ -1,7 +1,7 @@
 // components/RemixPicker.tsx
 "use client";
 
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 
 type Props = {
   open: boolean;
@@ -19,6 +19,18 @@ const ALL_APIS = [
 
 export default function RemixPicker({ open, onClose, onConfirm }: Props) {
   const [selected, setSelected] = useState<string[]>([]);
+
+  useEffect(() => setSelected([]), [open]);
+
+  useEffect(() => {
+    if (!open) return;
+    const handle = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    };
+    window.addEventListener("keydown", handle);
+    return () => window.removeEventListener("keydown", handle);
+  }, [open, onClose]);
+
   if (!open) return null;
 
   function toggle(name: string) {


### PR DESCRIPTION
## Summary
- reset selection state whenever dialog opens
- close RemixPicker when Escape is pressed, cleaning up the handler on unmount

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689a5197ba688321aadc7919866d0f95