### PR TITLE
feat: improve OpenAI provider error handling

### DIFF
--- a/placeholder-main/components/ai/providers.ts
+++ b/placeholder-main/components/ai/providers.ts
@@ -10,11 +10,16 @@ export const registry: Record<string, Provider> = {
   openai: {
     name: 'OpenAI',
     async generate({ prompt, model = 'gpt-4o-mini' }, { apiKey }) {
+      const headers: Record<string, string> = { 'Content-Type': 'application/json' };
+      if (apiKey) headers.Authorization = `Bearer ${apiKey}`;
       const r = await fetch('https://api.openai.com/v1/chat/completions', {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${apiKey}` },
+        headers,
         body: JSON.stringify({ model, messages: [{ role: 'user', content: prompt }] }),
       });
+      if (!r.ok) {
+        throw new Error(`OpenAI error ${r.status}: ${await r.text()}`);
+      }
       const j = await r.json();
       return j?.choices?.[0]?.message?.content ?? '';
     }


### PR DESCRIPTION
## Summary
- build OpenAI fetch headers only when apiKey is present
- throw informative error when OpenAI API responds unsuccessfully

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_689a51988028832182413d200978c17a