### PR TITLE
Ensure hasMore uses incremented page value

### DIFF
--- a/placeholder-main/app/page.tsx
+++ b/placeholder-main/app/page.tsx
@@ -49,8 +49,9 @@ export default function Page() {
         setTimeout(() => {
           const next = makeBatch(page * 12, 12);
           setItems((prev) => [...prev, ...next]);
-          setPage((p) => p + 1);
-          if (page >= 10) setHasMore(false); // demo cap
+          const nextPage = page + 1;
+          setPage(nextPage);
+          if (nextPage >= 10) setHasMore(false); // demo cap
           setLoading(false);
         }, 220);
       },


### PR DESCRIPTION
## Summary
- Prevent stale `hasMore` checks by storing `page + 1` in `nextPage`
- Use `nextPage` for `setPage` and in `hasMore` comparison

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_689a519dc1b8832186c8acfc10a4bf9f