### PR TITLE
Improve fetch error handling in API helpers

### DIFF
--- a/placeholder-main/lib/api.ts
+++ b/placeholder-main/lib/api.ts
@@ -2,23 +2,53 @@
 const BASE = process.env.NEXT_PUBLIC_BACKEND_URL || 'http://127.0.0.1:8000';
 
 export async function getStatus() {
-  const r = await fetch(`${BASE}/status`, { cache: 'no-store' });
-  if (!r.ok) throw new Error('status failed');
+  let r: Response;
+  try {
+    r = await fetch(`${BASE}/status`, { cache: 'no-store' });
+  } catch (err) {
+    throw new Error(
+      `Network error while fetching status: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+  if (!r.ok) {
+    const body = await r.text();
+    throw new Error(`status ${r.status}: ${body.slice(0, 100)}`);
+  }
   return r.json();
 }
 
 export async function getEntropy() {
-  const r = await fetch(`${BASE}/system/collective-entropy`, { cache: 'no-store' });
-  if (!r.ok) throw new Error('entropy failed');
+  let r: Response;
+  try {
+    r = await fetch(`${BASE}/system/collective-entropy`, { cache: 'no-store' });
+  } catch (err) {
+    throw new Error(
+      `Network error while fetching entropy: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+  if (!r.ok) {
+    const body = await r.text();
+    throw new Error(`entropy ${r.status}: ${body.slice(0, 100)}`);
+  }
   return r.json();
 }
 
 export async function aiAssist(vibenodeId: number, prompt: string, token: string) {
-  const r = await fetch(`${BASE}/ai-assist/${vibenodeId}`, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
-    body: JSON.stringify({ prompt }),
-  });
-  if (!r.ok) throw new Error('ai-assist failed');
+  let r: Response;
+  try {
+    r = await fetch(`${BASE}/ai-assist/${vibenodeId}`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
+      body: JSON.stringify({ prompt }),
+    });
+  } catch (err) {
+    throw new Error(
+      `Network error while calling ai-assist: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+  if (!r.ok) {
+    const body = await r.text();
+    throw new Error(`ai-assist ${r.status}: ${body.slice(0, 100)}`);
+  }
   return r.json();
 }


### PR DESCRIPTION
## Summary
- provide clearer network error messages for API fetches
- include status code and response snippet when requests fail

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_689a51a16a3c83218566b9fe4640f8f3