### PR TITLE
Handle onChange errors in ReactionBar

### DIFF
--- a/placeholder-main/components/ReactionBar.tsx
+++ b/placeholder-main/components/ReactionBar.tsx
@@ -42,7 +42,12 @@ export default function ReactionBar({
 
   const handleClick = (next: string) => {
     setSelected(prev => {
-      try { onChange?.(prev, next); } catch { /* swallow */ }
+      try {
+        onChange?.(prev, next);
+      } catch (err) {
+        // Surface errors from the onChange handler instead of silently swallowing them
+        console.error(err);
+      }
       // toggle: clicking the same reaction keeps it selected (no unlike yet)
       return next;
     });


### PR DESCRIPTION
## Summary
- avoid swallowing onChange errors in ReactionBar by logging failures

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689a51a799e883219c26554436362b45