### PR TITLE
fix: specify button type in PortalHero

### DIFF
--- a/placeholder-main/components/PortalHero.tsx
+++ b/placeholder-main/components/PortalHero.tsx
@@ -254,6 +254,7 @@ export default function PortalHero({ logoSrc = '/icon.png' }: { logoSrc?: string
             )}
             <Html center>
               <button
+                type="button"
                 aria-label="Open 3D portal"
                 onClick={() => setOpen(true)}
                 style={{


### PR DESCRIPTION
## Summary
- add explicit `type="button"` to PortalHero entry button

## Testing
- `npm test` (fails: Missing script "test")

------
https://chatgpt.com/codex/tasks/task_e_689a60bf90548321b9757d28eefa9776