### PR TITLE
fix: give codex toggle explicit button semantics

### DIFF
--- a/placeholder-main/components/CodexPrompt.tsx
+++ b/placeholder-main/components/CodexPrompt.tsx
@@ -51,7 +51,7 @@ export default function CodexPrompt() {
       <header className="row">
         <strong>Stable bug‑fix agent prompt</strong>
         <div className="grow" />
-        <button className="chip" onClick={toggle}>{collapsed ? 'Show' : 'Hide'}</button>
+        <button type="button" className="chip" onClick={toggle} aria-pressed={!collapsed}>{collapsed ? 'Show' : 'Hide'}</button>
       </header>
 
       {!collapsed && (


### PR DESCRIPTION
## Summary
- prevent CodexPrompt toggle from acting as form submit
- expose toggle state via `aria-pressed`

## Testing
- `npm test` *(fails: Missing script "test")*
- `npx tsc -p tsconfig.json --noEmit` *(fails: Cannot find module 'next/og' etc.)*

------
https://chatgpt.com/codex/tasks/task_e_689a60bc92ac83219d5b9277e4f1731b