### PR TITLE
feat: allow reaction deselection in ReactionBar

### DIFF
--- a/placeholder-main/components/PostCard.tsx
+++ b/placeholder-main/components/PostCard.tsx
@@ -20,7 +20,7 @@ export default function PostCard({
   onReact,
 }: {
   post: Post;
-  onReact?: (prev: string | null, next: string) => void;
+  onReact?: (prev: string | null, next: string | null) => void;
 }) {
   const p = post as unknown as AnyObj; // tolerate partial data without exploding
   const handleReact = onReact ?? (() => {});

--- a/placeholder-main/components/ReactionBar.tsx
+++ b/placeholder-main/components/ReactionBar.tsx
@@ -10,8 +10,8 @@ export type Props = {
   postId?: string;
   /** Map of emoji -> count. Missing keys default to 0. */
   counts?: ReactionCounts;
-  /** Notifies parent of a change: previous selection (or null) and new selection */
-  onChange?: (prev: string | null, next: string) => void;
+  /** Notifies parent of a change: previous selection (or null) and new selection (or null) */
+  onChange?: (prev: string | null, next: string | null) => void;
   /** Optional className so parent can style/position */
   className?: string;
 };
@@ -43,9 +43,10 @@ export default function ReactionBar({
 
   const handleClick = (next: string) => {
     setSelected(prev => {
-      try { onChange?.(prev, next); } catch { /* swallow */ }
-      // toggle: clicking the same reaction keeps it selected (no unlike yet)
-      return next;
+      const result = prev === next ? null : next;
+      try { onChange?.(prev, result); } catch { /* swallow */ }
+      // toggle: clicking again clears the selection
+      return result;
     });
   };
 


### PR DESCRIPTION
## Summary
- allow users to deselect reaction by clicking the active emoji
- propagate deselection via onChange and update PostCard type

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689a52ad6f388321bad1ae2bed5a118a