### PR TITLE
feat: add social cross-post integrations

### DIFF
--- a/placeholder-main/app/page.tsx
+++ b/placeholder-main/app/page.tsx
@@ -8,6 +8,7 @@ import dynamic from 'next/dynamic';
 
 // 3D hero (no SSR)
 const PortalHero = dynamic(() => import('@/components/PortalHero'), { ssr: false });
+import PostComposer from '@/components/PostComposer';
 
 type Post = { id: string; author: string; text: string; time: string; image?: string };
 
@@ -251,6 +252,8 @@ export default function Page() {
               <button className="btn">Remix a Universe</button>
             </div>
           </div>
+
+          <PostComposer />
 
           {/* feed */}
           {items.map((p) => (

--- a/placeholder-main/components/CrossPostToggles.tsx
+++ b/placeholder-main/components/CrossPostToggles.tsx
@@ -1,0 +1,46 @@
+// components/CrossPostToggles.tsx
+'use client';
+
+import React from 'react';
+
+export type CrossPostSelection = {
+  linkedin: boolean;
+  instagram: boolean;
+};
+
+type Props = {
+  value: CrossPostSelection;
+  onChange: (v: CrossPostSelection) => void;
+};
+
+export default function CrossPostToggles({ value, onChange }: Props) {
+  const toggle = (k: keyof CrossPostSelection) => {
+    onChange({ ...value, [k]: !value[k] });
+  };
+
+  return (
+    <div className="crossPosts">
+      <label className={value.linkedin ? 'on' : ''}>
+        <input
+          type="checkbox"
+          checked={value.linkedin}
+          onChange={() => toggle('linkedin')}
+        />
+        <span>LinkedIn</span>
+      </label>
+      <label className={value.instagram ? 'on' : ''}>
+        <input
+          type="checkbox"
+          checked={value.instagram}
+          onChange={() => toggle('instagram')}
+        />
+        <span>Instagram</span>
+      </label>
+      <style jsx>{`
+        .crossPosts { display:flex; gap:12px; margin:8px 0; }
+        label { display:flex; align-items:center; gap:4px; font-size:14px; }
+        label.on span { color: var(--pink); }
+      `}</style>
+    </div>
+  );
+}

--- a/placeholder-main/components/PostComposer.tsx
+++ b/placeholder-main/components/PostComposer.tsx
@@ -1,0 +1,61 @@
+// components/PostComposer.tsx
+'use client';
+
+import { useState } from 'react';
+import CrossPostToggles, {
+  CrossPostSelection,
+} from '@/components/CrossPostToggles';
+import {
+  postToInstagram,
+  postToLinkedIn,
+} from '@/libs/socialIntegrations';
+
+export default function PostComposer() {
+  const [text, setText] = useState('');
+  const [dest, setDest] = useState<CrossPostSelection>({
+    linkedin: false,
+    instagram: false,
+  });
+
+  const submit = async () => {
+    // Placeholder access tokens; production would obtain via OAuth.
+    const dummyToken = '';
+    try {
+      if (dest.linkedin)
+        await postToLinkedIn({ accessToken: dummyToken, content: text });
+      if (dest.instagram)
+        await postToInstagram({ accessToken: dummyToken, content: text });
+      setText('');
+    } catch (err) {
+      console.error(err);
+    }
+  };
+
+  return (
+    <div className="card composer">
+      <textarea
+        placeholder="Share something..."
+        value={text}
+        onChange={(e) => setText(e.target.value)}
+      />
+      <CrossPostToggles value={dest} onChange={setDest} />
+      <button className="btn primary" onClick={submit} disabled={!text.trim()}>
+        Post
+      </button>
+      <style jsx>{`
+        .composer { display:flex; flex-direction:column; gap:8px; margin-bottom:16px; }
+        textarea {
+          width:100%;
+          min-height:60px;
+          border-radius:12px;
+          background:#0c0e14;
+          border:1px solid var(--stroke);
+          color:var(--ink);
+          padding:8px;
+          resize:vertical;
+        }
+        button { align-self:flex-end; }
+      `}</style>
+    </div>
+  );
+}

--- a/placeholder-main/libs/socialIntegrations.ts
+++ b/placeholder-main/libs/socialIntegrations.ts
@@ -1,0 +1,127 @@
+// libs/socialIntegrations.ts
+// Minimal API clients for third-party social platforms.
+// These helpers respect each platform's OAuth flow and use fetch for network calls.
+
+export type CrossPostPayload = {
+  accessToken: string;
+  content: string;
+};
+
+export function getLinkedInAuthUrl(params: {
+  clientId: string;
+  redirectUri: string;
+  state: string;
+  scope?: string;
+}): string {
+  const scope = encodeURIComponent(
+    params.scope ?? 'openid profile w_member_social'
+  );
+  return `https://www.linkedin.com/oauth/v2/authorization?response_type=code&client_id=${encodeURIComponent(
+    params.clientId
+  )}&redirect_uri=${encodeURIComponent(
+    params.redirectUri
+  )}&state=${encodeURIComponent(params.state)}&scope=${scope}`;
+}
+
+export async function exchangeLinkedInCode(params: {
+  clientId: string;
+  clientSecret: string;
+  redirectUri: string;
+  code: string;
+}): Promise<string> {
+  const res = await fetch('https://www.linkedin.com/oauth/v2/accessToken', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body: new URLSearchParams({
+      grant_type: 'authorization_code',
+      code: params.code,
+      redirect_uri: params.redirectUri,
+      client_id: params.clientId,
+      client_secret: params.clientSecret,
+    }),
+  });
+  if (!res.ok) throw new Error(`LinkedIn token exchange failed: ${res.status}`);
+  const json = await res.json();
+  return json.access_token as string;
+}
+
+export async function postToLinkedIn(
+  payload: CrossPostPayload
+): Promise<unknown> {
+  const res = await fetch('https://api.linkedin.com/v2/ugcPosts', {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${payload.accessToken}`,
+      'Content-Type': 'application/json',
+      'X-Restli-Protocol-Version': '2.0.0',
+    },
+    body: JSON.stringify({
+      author: 'urn:li:person:me',
+      lifecycleState: 'PUBLISHED',
+      specificContent: {
+        'com.linkedin.ugc.ShareContent': {
+          shareCommentary: { text: payload.content },
+          shareMediaCategory: 'NONE',
+        },
+      },
+      visibility: {
+        'com.linkedin.ugc.MemberNetworkVisibility': 'PUBLIC',
+      },
+    }),
+  });
+  if (!res.ok) throw new Error(`LinkedIn post failed: ${res.status}`);
+  return res.json();
+}
+
+export function getInstagramAuthUrl(params: {
+  clientId: string;
+  redirectUri: string;
+  state: string;
+  scope?: string;
+}): string {
+  const scope = encodeURIComponent(params.scope ?? 'user_profile,user_media');
+  return `https://api.instagram.com/oauth/authorize?response_type=code&client_id=${encodeURIComponent(
+    params.clientId
+  )}&redirect_uri=${encodeURIComponent(
+    params.redirectUri
+  )}&state=${encodeURIComponent(params.state)}&scope=${scope}`;
+}
+
+export async function exchangeInstagramCode(params: {
+  clientId: string;
+  clientSecret: string;
+  redirectUri: string;
+  code: string;
+}): Promise<string> {
+  const res = await fetch('https://api.instagram.com/oauth/access_token', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body: new URLSearchParams({
+      grant_type: 'authorization_code',
+      code: params.code,
+      redirect_uri: params.redirectUri,
+      client_id: params.clientId,
+      client_secret: params.clientSecret,
+    }),
+  });
+  if (!res.ok) throw new Error(`Instagram token exchange failed: ${res.status}`);
+  const json = await res.json();
+  return json.access_token as string;
+}
+
+export async function postToInstagram(
+  payload: CrossPostPayload
+): Promise<unknown> {
+  const res = await fetch(
+    `https://graph.facebook.com/v18.0/me/media?access_token=${encodeURIComponent(
+      payload.accessToken
+    )}`,
+    {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ caption: payload.content }),
+    }
+  );
+  if (!res.ok) throw new Error(`Instagram post failed: ${res.status}`);
+  return res.json();
+}


### PR DESCRIPTION
## Summary
- add socialIntegrations module with LinkedIn and Instagram OAuth and posting helpers
- create cross-post toggle UI and composer component
- wire composer into feed page for cross-post selection

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689a616c4de48321b4c323c8c2460bd0