### PR TITLE
Use dynamic imports for ThreePanel 3D components

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+placeholder-main/node_modules/

--- a/placeholder-main/components/ThreePanel.tsx
+++ b/placeholder-main/components/ThreePanel.tsx
@@ -1,9 +1,14 @@
 // components/ThreePanel.tsx
 "use client";
 
-import React, { useState } from "react";
-import { Canvas } from "@react-three/fiber";
-import Mini3D from "./Mini3D";
+import { useState } from "react";
+import dynamic from "next/dynamic";
+
+const Canvas = dynamic(() => import("@react-three/fiber").then((m) => m.Canvas), {
+  ssr: false,
+});
+
+const Mini3D = dynamic(() => import("./Mini3D"), { ssr: false });
 
 type Props = {
   seed?: string;


### PR DESCRIPTION
## Summary
- Load `Canvas` and `Mini3D` via dynamic imports with `ssr: false` to avoid server-side rendering
- Drop unused React default import and keep `useState`
- Add `.gitignore` to exclude `node_modules`

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npx tsc -p tsconfig.json --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_689a622dde8883219c8b4f2c0f168474