### PR TITLE
Log agent fetch errors and show fallback message

### DIFF
--- a/placeholder-main/components/AgentsRail.tsx
+++ b/placeholder-main/components/AgentsRail.tsx
@@ -15,6 +15,7 @@ type Agent = {
 
 export default function AgentsRail() {
   const [agents, setAgents] = useState<Agent[]>([]);
+  const [error, setError] = useState(false);
 
   useEffect(() => {
     const controller = new AbortController();
@@ -22,14 +23,9 @@ export default function AgentsRail() {
       try {
         const data = await api.listAgents(controller.signal);
         if (!controller.signal.aborted) setAgents(data);
-      } catch {
-        if (!controller.signal.aborted)
-          setAgents([
-            { id: "a1", handle: "nova_ai", display_name: "Nova AI", resonance: 98 },
-            { id: "a2", handle: "karina", display_name: "Karina", resonance: 91 },
-            { id: "a3", handle: "ning", display_name: "Ning", resonance: 89 },
-            { id: "a4", handle: "minji", display_name: "Minji", resonance: 86 },
-          ]);
+      } catch (err) {
+        console.error(err);
+        if (!controller.signal.aborted) setError(true);
       }
     })();
     return () => {
@@ -37,6 +33,7 @@ export default function AgentsRail() {
     };
   }, []);
 
+  if (error) return <div>failed to load agents</div>;
   if (!agents.length) return null;
 
   return (


### PR DESCRIPTION
## Summary
- log agent fetch errors via `console.error`
- show a simple "failed to load agents" message when the agent list fails to load

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689a61ce589483218e655442ced8f5b5