### PR TITLE
Dynamically import Canvas in 3D page

### DIFF
--- a/placeholder-main/app/3d/page.tsx
+++ b/placeholder-main/app/3d/page.tsx
@@ -1,7 +1,9 @@
 'use client';
 
-import { Canvas } from '@react-three/fiber';
+import dynamic from 'next/dynamic';
 import { OrbitControls, Float } from '@react-three/drei';
+
+const Canvas = dynamic(() => import('@react-three/fiber').then(m => m.Canvas), { ssr: false });
 
 export default function Page3D() {
   return (


### PR DESCRIPTION
## Summary
- Dynamically import React Three Fiber's `Canvas` component to disable SSR in `/3d`

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689a61f476e883219008c8d17524345e