### PR TITLE
feat: add descriptive avatar alt text

### DIFF
--- a/placeholder-main/components/PostCard.tsx
+++ b/placeholder-main/components/PostCard.tsx
@@ -42,7 +42,11 @@ export default function PostCard({
       <header className={styles.header}>
         {post.author?.avatar ? (
           // using <img> to avoid Next/Image config for now
-          <img className={styles.avatar} src={post.author.avatar} alt="" />
+          <img
+            className={styles.avatar}
+            src={post.author.avatar}
+            alt={`${post.author?.name ?? 'anon'} avatar`}
+          />
         ) : (
           <div className={styles.avatar} aria-hidden />
         )}


### PR DESCRIPTION
## Summary
- use author name in PostCard avatar alt text for accessibility

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689a61ba25688321bef961bde958e8cd