### PR TITLE
Add Instagram and LinkedIn connectors

### DIFF
--- a/placeholder-main/components/Sidebar.tsx
+++ b/placeholder-main/components/Sidebar.tsx
@@ -182,6 +182,22 @@ export default function Sidebar({ open, onClose }: SidebarProps) {
           >
             Google Cloud
           </Link>
+          <Link
+            href="https://www.instagram.com/oauth/authorize"
+            target="_blank"
+            rel="noopener noreferrer"
+            className={styles.connector}
+          >
+            Instagram
+          </Link>
+          <Link
+            href="https://www.linkedin.com/oauth/v2/authorization"
+            target="_blank"
+            rel="noopener noreferrer"
+            className={styles.connector}
+          >
+            LinkedIn
+          </Link>
         </div>
 
         <div className={styles.ctaWrap}>

--- a/placeholder-main/components/sidebar.module.css
+++ b/placeholder-main/components/sidebar.module.css
@@ -107,6 +107,32 @@
     0 0 0 1px rgba(255,255,255,.10) inset;
 }
 
+/* Grid of external integrations */
+.connectGrid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+  gap: 8px;
+  padding: 0 4px 12px 4px;
+}
+
+.connector {
+  display: block;
+  padding: 8px 12px;
+  border-radius: 12px;
+  color: #e9eef5;
+  text-align: center;
+  text-decoration: none;
+  border: 1px solid rgba(255,255,255,.10);
+  background: rgba(16,18,27,.75);
+  backdrop-filter: blur(6px);
+  transition: background .15s ease, border-color .15s ease;
+}
+
+.connector:hover {
+  background: rgba(23,26,37,.88);
+  border-color: rgba(255,255,255,.18);
+}
+
 /* Optional small “pill” footer area */
 .footer {
   margin-top: auto;


### PR DESCRIPTION
## Summary
- add Instagram and LinkedIn OAuth links to sidebar connect grid
- style connect grid and connectors for additional OAuth items

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_689a61a962b08321aa6fc066d3c7311a